### PR TITLE
feat(Mobile): Allow psr/log compatibility. #NMA-1341

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": "^7.2||^8.1",
-    "graylog2/gelf-php": "^1.6",
+    "graylog2/gelf-php": "^1.6||^2.0",
     "monolog/monolog": "^2.9.0"
   },
   "require-dev": {


### PR DESCRIPTION
This adds compatibility for `psr/log` version.

Version `1.7.1` `(^1.6)` of `graylog2/gelf-php` requires `psr/log: ^1.0|^2.0` but bundle `sensiolabs/gotenberg-bundle` on last version requires `"psr/log": "^3.0"`, which prevent bundle installation.
`graylog2/gelf-php:^2.0` supports `psr/log: ^1|^2|^3`


https://shippeo.atlassian.net/browse/NMA-1341